### PR TITLE
Add `commit_message` to be a rolling-update trigger

### DIFF
--- a/app/apis/api_kubernetes.py
+++ b/app/apis/api_kubernetes.py
@@ -1049,6 +1049,7 @@ class ApiKubernetesIdApplicationIdServiceId(Resource):
             raise Exception("No such data.")
         args["app_name"] = aobj.application_name
         args["service_level"] = sobj.service_level
+        args['commit_message'] = "Request a rolling-update at {0:%Y%m%d%H%M%S}".format(datetime.utcnow())
         create_or_update_drucker_on_kubernetes(kubernetes_id, args, sobj.service_name)
         applist = set((aobj.application_name,))
         update_dbs_kubernetes(kubernetes_id, applist)


### PR DESCRIPTION
## What is this PR for?

After this modification, you can do a rolling-update when you push `rolling-update` button even if you don't change any configurations.

## This PR includes

- Fill `commit_message` automatically

## What type of PR is it?

Feature

## What is the issue?

N/A

## How should this be tested?

Push `rolling-update` button without changing the configurations.