### PR TITLE
Add convert function and fix wrong cpu values

### DIFF
--- a/app/apis/api_kubernetes.py
+++ b/app/apis/api_kubernetes.py
@@ -11,8 +11,8 @@ from models.application import Application
 from models.service import Service
 from models.model import Model
 
-from utils.env_loader import DIR_KUBE_CONFIG, DRUCKER_GRPC_VERSION
-from apis.common import DatetimeToTimestamp
+from utils.env_loader import DIR_KUBE_CONFIG
+from apis.common import DatetimeToTimestamp, kubernetes_cpu_to_float
 
 
 kube_info_namespace = Namespace('kubernetes', description='Kubernetes Endpoint.')
@@ -647,7 +647,7 @@ def create_or_update_drucker_on_kubernetes(
         spec=client.V1beta1IngressSpec(
             rules=[
                 client.V1beta1IngressRule(
-                    host="{0}-{1}-{2}.{3}".format(app_name,DRUCKER_GRPC_VERSION,service_level,app_dns_name),
+                    host="{0}-{1}.{2}".format(app_name,service_level,app_dns_name),
                     http=client.V1beta1HTTPIngressRuleValue(
                         paths=[
                             client.V1beta1HTTPIngressPath(
@@ -1024,7 +1024,7 @@ class ApiKubernetesIdApplicationIdServiceId(Resource):
         response_body["policy_max_unavailable"] = v1_deployment.spec.strategy.rolling_update.max_unavailable
         response_body["policy_wait_seconds"] = v1_deployment.spec.min_ready_seconds
         response_body["container_image"] = v1_deployment.spec.template.spec.containers[0].image
-        response_body["resource_request_cpu"] = v1_deployment.spec.template.spec.containers[0].resources.requests["cpu"]
+        response_body["resource_request_cpu"] = kubernetes_cpu_to_float(v1_deployment.spec.template.spec.containers[0].resources.requests["cpu"])
         response_body["resource_request_memory"] = v1_deployment.spec.template.spec.containers[0].resources.requests["memory"]
         response_body["resource_limit_cpu"] = v1_deployment.spec.template.spec.containers[0].resources.limits["cpu"]
         response_body["resource_limit_memory"] = v1_deployment.spec.template.spec.containers[0].resources.limits["memory"]

--- a/app/apis/api_kubernetes.py
+++ b/app/apis/api_kubernetes.py
@@ -11,7 +11,7 @@ from models.application import Application
 from models.service import Service
 from models.model import Model
 
-from utils.env_loader import DIR_KUBE_CONFIG
+from utils.env_loader import DIR_KUBE_CONFIG, DRUCKER_GRPC_VERSION
 from apis.common import DatetimeToTimestamp, kubernetes_cpu_to_float
 
 
@@ -647,7 +647,7 @@ def create_or_update_drucker_on_kubernetes(
         spec=client.V1beta1IngressSpec(
             rules=[
                 client.V1beta1IngressRule(
-                    host="{0}-{1}.{2}".format(app_name,service_level,app_dns_name),
+                    host="{0}-{1}-{2}.{3}".format(app_name,DRUCKER_GRPC_VERSION,service_level,app_dns_name),
                     http=client.V1beta1HTTPIngressRuleValue(
                         paths=[
                             client.V1beta1HTTPIngressPath(

--- a/app/apis/api_kubernetes.py
+++ b/app/apis/api_kubernetes.py
@@ -1026,7 +1026,7 @@ class ApiKubernetesIdApplicationIdServiceId(Resource):
         response_body["container_image"] = v1_deployment.spec.template.spec.containers[0].image
         response_body["resource_request_cpu"] = kubernetes_cpu_to_float(v1_deployment.spec.template.spec.containers[0].resources.requests["cpu"])
         response_body["resource_request_memory"] = v1_deployment.spec.template.spec.containers[0].resources.requests["memory"]
-        response_body["resource_limit_cpu"] = v1_deployment.spec.template.spec.containers[0].resources.limits["cpu"]
+        response_body["resource_limit_cpu"] = kubernetes_cpu_to_float(v1_deployment.spec.template.spec.containers[0].resources.limits["cpu"])
         response_body["resource_limit_memory"] = v1_deployment.spec.template.spec.containers[0].resources.limits["memory"]
         response_body["host_model_dir"] = v1_deployment.spec.template.spec.volumes[0].host_path.path
         response_body["pod_model_dir"] = v1_deployment.spec.template.spec.containers[0].volume_mounts[0].mount_path

--- a/app/apis/common.py
+++ b/app/apis/common.py
@@ -7,3 +7,26 @@ logger = SystemLogger(logger_name="drucker_dashboard")
 class DatetimeToTimestamp(fields.Raw):
     def format(self, value):
         return value.timestamp()
+
+
+decimal_suffixes = {
+    'm': 1.0e-3,
+    'k': 1.0e+3,
+    'M': 1.0e+6,
+    'G': 1.0e+9,
+    'T': 1.0e+12,
+    'P': 1.0e+15,
+    'E': 1.0e+18,
+}
+
+
+def kubernetes_cpu_to_float(cpu_str: str):
+    """ Convert the Kubernetes CPU value to float """
+    suffix = cpu_str[-1]
+    if suffix.isnumeric():
+        return float(cpu_str)
+    elif suffix in decimal_suffixes.keys():
+        value = float(cpu_str[:-1])
+        return value * decimal_suffixes[suffix]
+    else:
+        raise ValueError(f'Please check the input CPU value: `{cpu_str}`')


### PR DESCRIPTION
## What is this PR for?

To add a convert function and fix the wrong cpu values in `ApiKubernetesIdApplicationIdServiceId`

## This PR includes

- A convert function to convert the CPU value from Kubernetes to float
- Apply the convert function

## What type of PR is it?

Bugfix

## What is the issue?

In Drucker, the CPU value should be represented in float but the CPU values from Kubernetes are in string types. This PR try to fix the wrong CPU values in `ApiKubernetesIdApplicationIdServiceId.get`.

## How should this be tested?

With this PR, `ApiKubernetesIdApplicationIdServiceId.get` will return the response sucessfully.