### PR TITLE
[Hotfix] Add `JWT_TOKEN_KEY` when fetch `rawMultiRequest`

### DIFF
--- a/frontend/src/apis/Core/index.tsx
+++ b/frontend/src/apis/Core/index.tsx
@@ -213,7 +213,16 @@ export async function rawMultiRequest<T = any>(
     }
   )
   const fullOptionsList = requestList.map(generateRawRequest)
-
+  const token = window.localStorage.getItem(JWT_TOKEN_KEY)
+  if (token) {
+    fullOptionsList.map(
+      (fullOptions) =>
+        fullOptions.headers = {
+          ...fullOptions.headers,
+          Authorization: `Bearer ${token}`
+        }
+    )
+  }
   return Promise.all(
     entryPoints.map(
       (entryPoint, i) =>


### PR DESCRIPTION
## What is this PR for?

Add `JWT_TOKEN_KEY` when fetch `rawMultiRequest`

## This PR includes

- Add `JWT_TOKEN_KEY` 

## What type of PR is it?

Bugfix

## What is the issue?

N/A

## How should this be tested?

`Switch model`
`Delete service`