### PR TITLE
[Hotfix] Allow `/api/settings` in auth module

### DIFF
--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -20,7 +20,7 @@ class Auth(object):
     def auth_required(fn):
         @wraps(fn)
         def wrapper(*args, **kwargs):
-            if Auth.enabled and request.path.startswith('/api/'):
+            if Auth.enabled and request.path != '/api/settings':
                 return jwt_required(fn(*args, **kwargs))
             else:
                 return fn(*args, **kwargs)


### PR DESCRIPTION
## What is this PR for?

Due to the change in #17, all API requests become error when authentication is enabled.
This is a hotfix for it.


## This PR includes

- Fix the path what `@auth_required` decorator ignores authentication processing


## What type of PR is it?

Bugfix


## What is the issue?

N/A

## How should this be tested?

Activated the `auth` part of `settings.yml`