### PR TITLE
[Hotfix] Specify non-auth endpoint

### DIFF
--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -20,8 +20,7 @@ class Auth(object):
     def auth_required(fn):
         @wraps(fn)
         def wrapper(*args, **kwargs):
-            if Auth.enabled and request.path.startswith('/api/') and \
-                    not request.path.startswith('/api/settings'):
+            if Auth.enabled and request.path.startswith('/api/') and not request.path.startswith('/api/settings'):
                 return jwt_required(fn(*args, **kwargs))
             else:
                 return fn(*args, **kwargs)

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -20,7 +20,8 @@ class Auth(object):
     def auth_required(fn):
         @wraps(fn)
         def wrapper(*args, **kwargs):
-            if Auth.enabled and request.path != '/api/settings':
+            if Auth.enabled and request.path.startswith('/api/') and \
+                    not request.path.startswith('/api/settings'):
                 return jwt_required(fn(*args, **kwargs))
             else:
                 return fn(*args, **kwargs)


### PR DESCRIPTION
## What is this PR for?

In #26 , we specified non `/api/settings` endpoint to be authenticated.
But because of this modification, we cannot use swagger ui now.

## This PR includes

- Add constraint `request.path.startswith('/api/')` and `not request.path.startswith('/api/settings')`

## What type of PR is it?

Hotfix

## What is the issue?

N/A

## How should this be tested?

Access to backend swagger UI
`http://localhost:18080/` in default.
