### PR TITLE
[Hotfix] Add encode info

### DIFF
--- a/app/apis/api_kubernetes.py
+++ b/app/apis/api_kubernetes.py
@@ -846,7 +846,7 @@ def dump_drucker_on_kubernetes(
               pathlib.Path(
                   DIR_KUBE_CONFIG,
                   aobj.application_name,
-                  "{0}-deployment.json".format(sobj.service_name)).open("w"),
+                  "{0}-deployment.json".format(sobj.service_name)).open("w", encoding='utf-8'),
               ensure_ascii = False, indent = 2)
     core_vi = client.CoreV1Api()
     v1_service = core_vi.read_namespaced_service(
@@ -859,7 +859,7 @@ def dump_drucker_on_kubernetes(
               pathlib.Path(
                   DIR_KUBE_CONFIG,
                   aobj.application_name,
-                  "{0}-service.json".format(sobj.service_name)).open("w"),
+                  "{0}-service.json".format(sobj.service_name)).open("w", encoding='utf-8'),
               ensure_ascii = False, indent = 2)
     extensions_v1_beta = client.ExtensionsV1beta1Api()
     v1_beta1_ingress = extensions_v1_beta.read_namespaced_ingress(
@@ -872,7 +872,7 @@ def dump_drucker_on_kubernetes(
               pathlib.Path(
                   DIR_KUBE_CONFIG,
                   aobj.application_name,
-                  "{0}-ingress.json".format(sobj.service_name)).open("w"),
+                  "{0}-ingress.json".format(sobj.service_name)).open("w", encoding='utf-8'),
               ensure_ascii = False, indent = 2)
     autoscaling_v1 = client.AutoscalingV1Api()
     v1_horizontal_pod_autoscaler = autoscaling_v1.read_namespaced_horizontal_pod_autoscaler(
@@ -885,7 +885,7 @@ def dump_drucker_on_kubernetes(
               pathlib.Path(
                   DIR_KUBE_CONFIG,
                   aobj.application_name,
-                  "{0}-autoscaling.json".format(sobj.service_name)).open("w"),
+                  "{0}-autoscaling.json".format(sobj.service_name)).open("w", encoding='utf-8'),
               ensure_ascii = False, indent = 2)
     """
     autoscaling_v2_beta1 = client.AutoscalingV2beta1Api()
@@ -899,7 +899,7 @@ def dump_drucker_on_kubernetes(
               pathlib.Path(
                   DIR_KUBE_CONFIG,
                   aobj.application_name,
-                  "{0}-autoscaling.json".format(sobj.service_name)).open("w"),
+                  "{0}-autoscaling.json".format(sobj.service_name)).open("w", encoding='utf-8'),
               ensure_ascii = False, indent = 2)
     """
 

--- a/docker-compose/docker-compose.develop.yaml
+++ b/docker-compose/docker-compose.develop.yaml
@@ -28,6 +28,7 @@ services:
       - ../app:/root/drucker-dashboard
     environment:
       FLASK_DEBUG: "True"
+      PYTHONIOENCODING: "utf-8"
     command:
       - /bin/bash
       - -c

--- a/docker-compose/docker-compose.production.yaml
+++ b/docker-compose/docker-compose.production.yaml
@@ -31,6 +31,7 @@ services:
       - ../app:/root/drucker-dashboard
     environment:
       FLASK_DEBUG: "False"
+      PYTHONIOENCODING: "utf-8"
     command:
       - /bin/bash
       - -c


### PR DESCRIPTION
## What is this PR for?

To dump a Kubernetes service configuration file, we have to specify an encoding info for Japanese characters.

## This PR includes

- Add encoding info when write file.

## What type of PR is it?

Bugfix

## What is the issue?

N/A

## How should this be tested?

Save Japanese character in `memo`