### PR TITLE
[Hotfix] Fix file upload limit for gRPC and flask

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -26,6 +26,7 @@ def configure_app(flask_app: Flask, db_url: str) -> None:
     flask_app.config['DEBUG'] = bool(os.getenv("FLASK_DEBUG", "True"))
     flask_app.config['SWAGGER_UI_DOC_EXPANSION'] = 'list'
     flask_app.config['RESTPLUS_VALIDATE'] = True
+    flask_app.config['MAX_CONTENT_LENGTH'] = int(os.getenv("FLASK_MAX_CONTENT_LENGTH", "1073741824"))
 
 
 def initialize_app(flask_app: Flask) -> None:

--- a/app/utils/protobuf_util.py
+++ b/app/utils/protobuf_util.py
@@ -19,6 +19,6 @@ class ProtobufUtil:
             return result
 
     @staticmethod
-    def stream_file(f:FileStorage, size:int=100*1024*1024) -> bytes:
+    def stream_file(f:FileStorage, size:int=4190000) -> bytes:
         for byte in iter(lambda: f.read(size), b''):
             yield byte


### PR DESCRIPTION
## What is this PR for?

Modify the file upload limit for gRPC and flask.
Since default gRPC settings limits 4MB data for transference in an one connection, we need to fix our file transference setting.

## This PR includes

- Specify file upload limit for flask
- Specify file transference limit for gRPC

## What type of PR is it?

Bugfix

## What is the issue?

N/A

## How should this be tested?

Upload ML model more than 4MB.