### PR TITLE
[Hotfix] Limit application name length

### DIFF
--- a/app/apis/api_kubernetes.py
+++ b/app/apis/api_kubernetes.py
@@ -94,7 +94,8 @@ kube_service_config_info = kube_info_namespace.model('Kubernetes service configu
     'app_name': fields.String(
         required=True,
         description='Application name.',
-        example='drucker-sample'
+        example='drucker-sample',
+        max_length=20
     ),
     'service_level': fields.String(
         required=True,
@@ -104,7 +105,8 @@ kube_service_config_info = kube_info_namespace.model('Kubernetes service configu
     'service_name': fields.String(
         readOnly=True,
         description='Service tag.',
-        example='dev-123456789'
+        example='dev-123456789',
+        max_length=20
     ),
     'service_port': fields.Integer(
         required=True,
@@ -359,6 +361,8 @@ def update_dbs_kubernetes(kubernetes_id:int, applist:set=None, description:str=N
 def create_or_update_drucker_on_kubernetes(
         kubernetes_id:int, args:dict, service_name:str=None):
     app_name = args['app_name']
+    if len(app_name) >= 20:
+        raise Exception("Application Name is too long. Up to 20.")
     service_level = args['service_level']
     service_port = args['service_port']
     replicas_default = args['replicas_default']

--- a/app/apis/api_kubernetes.py
+++ b/app/apis/api_kubernetes.py
@@ -361,7 +361,7 @@ def update_dbs_kubernetes(kubernetes_id:int, applist:set=None, description:str=N
 def create_or_update_drucker_on_kubernetes(
         kubernetes_id:int, args:dict, service_name:str=None):
     app_name = args['app_name']
-    if len(app_name) >= 20:
+    if len(app_name) > 20:
         raise Exception("Application Name is too long. Up to 20.")
     service_level = args['service_level']
     service_port = args['service_port']

--- a/frontend/src/components/Common/Field/Validateors.tsx
+++ b/frontend/src/components/Common/Field/Validateors.tsx
@@ -14,3 +14,6 @@ export const nameFormat = (value) =>
     (value && !/^[\w-]+$/.test(value)
      ? 'Must be write in [0-9a-zA-Z_-]+' : undefined)
 export const applicationNameFormat = nameFormat
+const maxLength = max => value =>
+  value && value.length > max ? `Must be ${max} characters or less` : undefined
+export const maxLength20 = maxLength(20)

--- a/frontend/src/components/misc/Forms/DeploymentSettingFormFields/index.tsx
+++ b/frontend/src/components/misc/Forms/DeploymentSettingFormFields/index.tsx
@@ -5,7 +5,7 @@ import { CardTitle, UncontrolledTooltip } from 'reactstrap'
 
 import { KubernetesHost, Model } from '@src/apis'
 import { SingleFormField } from '@common/Field/SingleFormField'
-import { required, applicationNameFormat } from '@common/Field/Validateors'
+import { required, applicationNameFormat, maxLength20 } from '@common/Field/Validateors'
 
 declare var REACT_APP_CONFIG: any
 
@@ -68,7 +68,7 @@ class DeploymentSettingFormFields extends React.Component<FormProps> {
         component={SingleFormField} type='text'
         className='form-control' id='applicationlName'
         formText={`Name of ${resource}, must be unique`}
-        validate={[required, applicationNameFormat]}
+        validate={[required, applicationNameFormat, maxLength20]}
         required
       />
     )


### PR DESCRIPTION
## What is this PR for?

Since Kubernetes metadata.name limits up to 63 characters, we need to restrict the length of application name.

## This PR includes

- Add restriction of `20` characters for application name.

## What type of PR is it?

Bugfix

## What is the issue?

N/A

## How should this be tested?

Input application name as more than 25 characters.