### PR TITLE
[Hotfix] Fix `switchModel` API response handler

### DIFF
--- a/app/apis/api_kubernetes.py
+++ b/app/apis/api_kubernetes.py
@@ -814,6 +814,7 @@ def switch_drucker_service_model_assignment(
             name="{0}-deployment".format(sobj.service_name),
             namespace=sobj.service_level
         )
+    response_body["status"] = True
     return response_body
 
 def dump_drucker_on_kubernetes(

--- a/frontend/src/apis/index.tsx
+++ b/frontend/src/apis/index.tsx
@@ -428,7 +428,7 @@ export async function switchModel(param: SwitchModelParam) {
   const requestBody = {
     model_id: param.modelId
   }
-  const convert = (result) => result.success
+  const convert = (result) => result.status
 
   return APICore.putJsonRequest(
     `${process.env.API_HOST}:${process.env.API_PORT}/api/applications/${param.applicationId}/services/${param.serviceId}`,
@@ -456,7 +456,7 @@ export async function switchModels(params: SwitchModelParam[]) {
         : `${process.env.API_HOST}:${process.env.API_PORT}/api/applications/${param.applicationId}/services/${param.serviceId}`
     )
   )
-  const convert = (result) => result.success
+  const convert = (result) => result.status
 
   return APICore.rawMultiRequest(entryPoints, convert, requestOptions)
 }


### PR DESCRIPTION
## What is this PR for?

Switching model is always shown as failure on WebUI but actually success.
This is because our API response handler didn't catch the status correctly.

## This PR includes

- Fix SwitchModel API response handler

## What type of PR is it?

Bugfix

## What is the issue?

N/A

## How should this be tested?

Switch model on WebUI.
