### PR TITLE
Make dump method independent from update method

### DIFF
--- a/app/apis/api_kubernetes.py
+++ b/app/apis/api_kubernetes.py
@@ -342,7 +342,6 @@ def update_dbs_kubernetes(kubernetes_id:int, applist:set=None, description:str=N
         else:
             sobj.confirm_date = datetime.utcnow()
             db.session.flush()
-        dump_drucker_on_kubernetes(kobj.kubernetes_id, aobj.application_id, sobj.service_id)
     for application_name in applist:
         aobj = db.session.query(Application).filter(
             Application.application_name == application_name,
@@ -816,27 +815,21 @@ def switch_drucker_service_model_assignment(
         )
     return response_body
 
+
 def dump_drucker_on_kubernetes(
-        kubernetes_id:int, application_id:int, service_id:int):
-    kobj = Kubernetes.query.filter_by(
-        kubernetes_id=kubernetes_id).one_or_none()
+        kobj:Kubernetes, aobj:Application, sobj:Service):
     if kobj is None:
         raise Exception("No such kubernetes_id.")
-    aobj = Application.query.filter_by(
-        application_id=application_id).one_or_none()
     if aobj is None:
         raise Exception("No such application_id.")
-    sobj = Service.query.filter_by(
-        service_id=service_id).one_or_none()
     if sobj is None:
         raise Exception("No such service_id.")
 
     config_path = kobj.config_path
     from kubernetes import client, config
     config.load_kube_config(config_path)
-    save_dir = pathlib.Path(DIR_KUBE_CONFIG, aobj.application_name)
-    if not os.path.isdir(save_dir):
-        os.mkdir(save_dir)
+    save_dir = pathlib.Path(DIR_KUBE_CONFIG, kobj.display_name, aobj.application_name)
+    save_dir.mkdir(parents=True, exist_ok=True)
     api_client = client.ApiClient()
 
     apps_v1 = client.AppsV1Api()
@@ -849,9 +842,10 @@ def dump_drucker_on_kubernetes(
     json.dump(api_client.sanitize_for_serialization(v1_deployment),
               pathlib.Path(
                   DIR_KUBE_CONFIG,
+                  kobj.display_name,
                   aobj.application_name,
                   "{0}-deployment.json".format(sobj.service_name)).open("w", encoding='utf-8'),
-              ensure_ascii = False, indent = 2)
+              ensure_ascii=False, indent=2)
     core_vi = client.CoreV1Api()
     v1_service = core_vi.read_namespaced_service(
         name="{0}-service".format(sobj.service_name),
@@ -862,9 +856,10 @@ def dump_drucker_on_kubernetes(
     json.dump(api_client.sanitize_for_serialization(v1_service),
               pathlib.Path(
                   DIR_KUBE_CONFIG,
+                  kobj.display_name,
                   aobj.application_name,
                   "{0}-service.json".format(sobj.service_name)).open("w", encoding='utf-8'),
-              ensure_ascii = False, indent = 2)
+              ensure_ascii=False, indent=2)
     extensions_v1_beta = client.ExtensionsV1beta1Api()
     v1_beta1_ingress = extensions_v1_beta.read_namespaced_ingress(
         name="{0}-ingress".format(sobj.service_name),
@@ -875,9 +870,10 @@ def dump_drucker_on_kubernetes(
     json.dump(api_client.sanitize_for_serialization(v1_beta1_ingress),
               pathlib.Path(
                   DIR_KUBE_CONFIG,
+                  kobj.display_name,
                   aobj.application_name,
                   "{0}-ingress.json".format(sobj.service_name)).open("w", encoding='utf-8'),
-              ensure_ascii = False, indent = 2)
+              ensure_ascii=False, indent=2)
     autoscaling_v1 = client.AutoscalingV1Api()
     v1_horizontal_pod_autoscaler = autoscaling_v1.read_namespaced_horizontal_pod_autoscaler(
         name="{0}-autoscaling".format(sobj.service_name),
@@ -888,9 +884,10 @@ def dump_drucker_on_kubernetes(
     json.dump(api_client.sanitize_for_serialization(v1_horizontal_pod_autoscaler),
               pathlib.Path(
                   DIR_KUBE_CONFIG,
+                  kobj.display_name,
                   aobj.application_name,
                   "{0}-autoscaling.json".format(sobj.service_name)).open("w", encoding='utf-8'),
-              ensure_ascii = False, indent = 2)
+              ensure_ascii=False, indent=2)
     """
     autoscaling_v2_beta1 = client.AutoscalingV2beta1Api()
     v2_beta1_horizontal_pod_autoscaler = autoscaling_v2_beta1.read_namespaced_horizontal_pod_autoscaler(
@@ -902,9 +899,10 @@ def dump_drucker_on_kubernetes(
     json.dump(api_client.sanitize_for_serialization(v2_beta1_horizontal_pod_autoscaler),
               pathlib.Path(
                   DIR_KUBE_CONFIG,
+                  kobj.display_name, 
                   aobj.application_name,
                   "{0}-autoscaling.json".format(sobj.service_name)).open("w", encoding='utf-8'),
-              ensure_ascii = False, indent = 2)
+              ensure_ascii=False, indent=2)
     """
 
 
@@ -972,6 +970,20 @@ class ApiKubernetes(Resource):
             os.remove(newkube.config_path)
             raise error
         return response_body
+
+
+@kube_info_namespace.route('/dump')
+class ApiKubernetesDump(Resource):
+    @kube_info_namespace.marshal_with(success_or_not)
+    def post(self):
+        """dump_kubernetes"""
+        for kobj in Kubernetes.query.all():
+            for aobj in Application.query.filter_by(kubernetes_id=kobj.kubernetes_id).all():
+                for sobj in Service.query.filter_by(application_id=aobj.application_id).all():
+                    dump_drucker_on_kubernetes(kobj, aobj, sobj)
+        response_body = {"status": True, "message": "Success."}
+        return response_body
+
 
 @kube_info_namespace.route('/<int:kubernetes_id>')
 class ApiKubernetesId(Resource):

--- a/app/app.py
+++ b/app/app.py
@@ -36,7 +36,7 @@ def initialize_app(flask_app: Flask) -> None:
     from utils.env_loader import DIR_KUBE_CONFIG, config
 
     if not os.path.isdir(DIR_KUBE_CONFIG):
-        os.mkdir(DIR_KUBE_CONFIG)
+        os.makedirs(DIR_KUBE_CONFIG)
     configure_app(flask_app, db_url())
 
     api.init_app(flask_app)

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -20,7 +20,7 @@ class Auth(object):
     def auth_required(fn):
         @wraps(fn)
         def wrapper(*args, **kwargs):
-            if Auth.enabled and request.path.startswith('/api/') and not request.path.startswith('/api/settings'):
+            if Auth.enabled and request.path.startswith('/api/') and not request.path.startswith('/api/settings') and not request.path.startswith('/api/kubernetes/dump'):
                 return jwt_required(fn(*args, **kwargs))
             else:
                 return fn(*args, **kwargs)


### PR DESCRIPTION
## What is this PR for?

Dumping Kubernetes Service info is too slow. We need to separate it from `update_dbs_kubernetes` method.

### Note
- Batch execution for dumping is out of scope on this PR.
- Exception rule of `app/auth/__init__.py` is a temporary. We will use `access_token` of the future expansion.

## This PR includes

- Create an endpoint for dump

## What type of PR is it?

Minor

## What is the issue?

#33 

## How should this be tested?

`Sync` on WebUI
