### PR TITLE
[Hotfix] Set "DRUCKER_TEST_MODE=False" when it deploys to Kubernetes

### DIFF
--- a/app/apis/api_kubernetes.py
+++ b/app/apis/api_kubernetes.py
@@ -416,6 +416,10 @@ def create_or_update_drucker_on_kubernetes(
             value=commit_message
         ),
         client.V1EnvVar(
+            name="DRUCKER_TEST_MODE",
+            value="False"
+        ),
+        client.V1EnvVar(
             name="DRUCKER_APPLICATION_NAME",
             value=app_name
         ),


### PR DESCRIPTION
## What is this PR for?

Set "DRUCKER_TEST_MODE=False" when it deploys to Kubernetes.
If "DRUCKER_TEST_MODE=True", Drucker uses test database but it's not appropriate for deployment.

## This PR includes

- Add "DRUCKER_TEST_MODE" env and set it to "False"

## What type of PR is it?

Bugfix

## What is the issue?

N/A

## How should this be tested?

Create Drucker app and create "settings.yml" which sets "test: True".
