### PR TITLE
[Hotfix] Use rekcurd dashboard root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,8 +104,7 @@ ENV/
 .idea/
 
 # sqlite
-db.sqlite3
-db.test.sqlite3
+*.db
 
 # Kube config
 kube-config/

--- a/e2e_test/cleanup.sh
+++ b/e2e_test/cleanup.sh
@@ -8,7 +8,8 @@ TEST_FILE_DIRECTORY=$(dirname "$0")
 minikube delete -p rekcurd-test1
 
 rm -f ${KUBE_CONFIG_PATH1:-/tmp/kube-config-path1}
-rm -f ${TEST_FILE_DIRECTORY}/db.test.sqlite3
+rm -f ${TEST_FILE_DIRECTORY}/*.test.db
+rm -f ~/.rekcurd/db/*.test.db
 
 
 # Done

--- a/rekcurd_dashboard/utils/rekcurd_dashboard_config.py
+++ b/rekcurd_dashboard/utils/rekcurd_dashboard_config.py
@@ -56,7 +56,7 @@ class RekcurdDashboardConfig:
             config = dict()
         self.DEBUG_MODE = config.get("debug", False)
         self.SERVICE_PORT = config.get("port", self.SERVICE_PORT)
-        self.DIR_KUBE_CONFIG = config.get("kube_config_dir", "kube-config")
+        self.DIR_KUBE_CONFIG = self.__kubeconfig_default_dir(config.get("kube_config_dir", "kube-config"))
         config_db = config.get("db", dict())
         db_mode = config_db.get("mode", "sqlite")
         config_db_mysql = config_db.get("mysql", dict())
@@ -77,7 +77,7 @@ class RekcurdDashboardConfig:
     def __load_from_env(self):
         self.DEBUG_MODE = os.getenv("DASHBOARD_DEBUG_MODE", "False").lower() == 'true'
         self.SERVICE_PORT = int(os.getenv("DASHBOARD_SERVICE_PORT", "{}".format(self.__SERVICE_DEFAULT_PORT)))
-        self.DIR_KUBE_CONFIG = os.getenv("DASHBOARD_KUBE_DATADIR")
+        self.DIR_KUBE_CONFIG = self.__kubeconfig_default_dir(os.getenv("DASHBOARD_KUBE_DATADIR", "kube-config"))
         db_mode = os.getenv('DASHBOARD_DB_MODE')
         db_host = os.getenv('DASHBOARD_DB_MYSQL_HOST')
         db_port = os.getenv('DASHBOARD_DB_MYSQL_PORT')
@@ -140,6 +140,11 @@ class RekcurdDashboardConfig:
             return f'mysql+pymysql://{db_username}:{db_password}@{db_host}:{db_port}/{db_name}?charset=utf8'
         else:
             raise TypeError("Invalid DB configurations.")
+
+    def __kubeconfig_default_dir(self, dirname: str):
+        root = os.path.abspath(
+            os.path.expanduser(os.getenv('REKCURD_DASHBOARD_ROOT', '~/.rekcurd')))
+        return os.path.join(root, dirname)
 
     def __sqlite_default_db_dir(self):
         root = os.path.abspath(

--- a/test/apis/test_kubernetes_handler.py
+++ b/test/apis/test_kubernetes_handler.py
@@ -30,7 +30,7 @@ class ApiSettingsTest(BaseTestCase):
         pass
 
     def test_get_full_config_path(self):
-        self.assertEqual('kube-config/tmp', get_full_config_path('tmp'))
+        self.assertTrue(get_full_config_path('tmp').endswith('kube-config/tmp'))
 
     def test_save_kubernetes_access_file(self):
         with open('test/dummy', 'rb') as fp:

--- a/test/utils/test_rekcurd_dashboard_config.py
+++ b/test/utils/test_rekcurd_dashboard_config.py
@@ -11,7 +11,7 @@ class RekcurdDashboardConfigTest(unittest.TestCase):
     def test_load_from_file(self):
         config = RekcurdDashboardConfig("./test/test-settings.yml")
         self.assertEqual(config.DEBUG_MODE, True)
-        self.assertEqual(config.SQLALCHEMY_DATABASE_URI, "sqlite:///db.test.sqlite3")
+        self.assertTrue(config.SQLALCHEMY_DATABASE_URI.endswith('rekcurd_dashboard.test.db'))
 
     def test_load_from_env(self):
         os.environ["DASHBOARD_KUBERNETES_MODE"] = "True"
@@ -21,7 +21,7 @@ class RekcurdDashboardConfigTest(unittest.TestCase):
         os.environ["DASHBOARD_LDAP_SEARCH_BASE_DNS"] = '["OU=user, DC=example, DC=com"]'
         config = RekcurdDashboardConfig("./test/test-settings.yml")
         self.assertEqual(config.DEBUG_MODE, False)
-        self.assertEqual(config.SQLALCHEMY_DATABASE_URI, "sqlite:///db.test.sqlite3")
+        self.assertTrue(config.SQLALCHEMY_DATABASE_URI.endswith('rekcurd_dashboard.test.db'))
         del os.environ["DASHBOARD_KUBERNETES_MODE"]
         del os.environ["DASHBOARD_DEBUG_MODE"]
         del os.environ["DASHBOARD_DB_MODE"]
@@ -34,4 +34,4 @@ class RekcurdDashboardConfigTest(unittest.TestCase):
             debug_mode=False, db_mode="mysql", db_host="localhost",
             db_port=1234, db_name="test", db_username="test", db_password="test")
         self.assertEqual(config.DEBUG_MODE, False)
-        self.assertEqual(config.SQLALCHEMY_DATABASE_URI, "sqlite:///db.test.sqlite3")
+        self.assertTrue(config.SQLALCHEMY_DATABASE_URI.endswith('rekcurd_dashboard.test.db'))


### PR DESCRIPTION
## What is this PR for?

We cannot control storing sqlite.db and kube-config.
I added "REKCURD_DASHBOARD_HOME" option to store these files.

## This PR includes

- Add "REKCURD_DASHBOARD_HOME" option

## What type of PR is it?

Hotfix

## What is the issue?

N/A

## How should this be tested?

```
$ python -m unittest
```